### PR TITLE
daqconf split 

### DIFF
--- a/scripts/snbmodules_multiru_multisnb_gen
+++ b/scripts/snbmodules_multiru_multisnb_gen
@@ -287,7 +287,7 @@ def cli(
         console.log("Loading dqm config generator")
         from daqconf.apps.dqm_gen import get_dqm_app
     console.log("Loading readout config generator")
-    from fddaqconf.apps.readout_gen import create_fake_readout_app, FDReadoutAppGenerator
+    from fddaqconf.apps.readout_gen import FDReadoutAppGenerator
     console.log("Loading trigger config generator")
     from daqconf.apps.trigger_gen import get_trigger_app
     console.log("Loading DFO config generator")
@@ -505,7 +505,7 @@ def cli(
                 )
 
         else:
-            the_system.apps[ru_name] = create_fake_readout_app(
+            the_system.apps[ru_name] = roapp_gen.create_fake_readout_app(
                 RU_DESCRIPTOR = ru_desc,
                 CLOCK_SPEED_HZ = detector.clock_speed_hz,
             )


### PR DESCRIPTION
There previous implementation had a bug and it was breaking the felix configuration. This issue is addressed in the following pull requests:
- `fddaqconf`: https://github.com/DUNE-DAQ/fddaqconf/pull/2
- `nddaqconf`: https://github.com/DUNE-DAQ/nddaqconf/pull/4
- `daqconf`: https://github.com/DUNE-DAQ/daqconf/pull/388
- `snbmodules`: https://github.com/DUNE-DAQ/snbmodules/pull/6

These also contain additional re-configuration required to preserve the common code in daqconf. 

All integration tests in daq-systemtest and lbrulibs are working as expected.

In addition, the felix configuration with the option use_fake_cards  set to false.

The files used are the following:

dro_map.json
daqconf.json
Both are attached in the daqconf pull request.