### PR TITLE
Removed sighup filters, ready for testing

### DIFF
--- a/integtest/simple_transform_test.py
+++ b/integtest/simple_transform_test.py
@@ -46,7 +46,6 @@ hsi_frag_params = {
 }
 ignored_logfile_problems = {
     "-controller": [
-        "Worker \(pid:\\d+\) was sent SIGHUP!",
         "Connection '.*' not found on the application registry",
     ],
     "connectivity-service": [


### PR DESCRIPTION
For testing the resolution of the connectivity service no longer getting SIGHUP
Part of https://github.com/DUNE-DAQ/daqsystemtest/pull/259