### PR TITLE
Remove the DataMoveCallbackRegistry, use IOManager callbacks instead.

### DIFF
--- a/include/snbmodules/readout/SNBDataHandlingModel.hpp
+++ b/include/snbmodules/readout/SNBDataHandlingModel.hpp
@@ -35,7 +35,6 @@
 #include "datahandlinglibs/concepts/DataHandlingConcept.hpp"
 #include "appmodel/DataHandlerModule.hpp"
 
-#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
 #include "datahandlinglibs/FrameErrorRegistry.hpp"
 
 #include "datahandlinglibs/concepts/LatencyBufferConcept.hpp"

--- a/include/snbmodules/readout/detail/SNBDataHandlingModel.hxx
+++ b/include/snbmodules/readout/detail/SNBDataHandlingModel.hxx
@@ -109,8 +109,8 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::conf(const appfwk::DAQModule::Com
     m_consume_callback = std::bind(&SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_callback, this, std::placeholders::_1);
  
     // Register callback
-    auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
-    dmcbr->register_callback<IDT>(m_raw_data_receiver_connection_name, m_consume_callback);
+    auto dmcbr = iomanager::IOManager::get();
+    dmcbr->add_callback<IDT>(m_raw_data_receiver_connection_name, m_consume_callback);
   }
 
   // Configure threads:


### PR DESCRIPTION
# Description

See DUNE-DAQ/datahandlinglibs#119 for details

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

