### PR TITLE
Check that the end of the request window is in the latency buffer

### DIFF
--- a/include/snbmodules/readout/SNBDataHandlingModel.hpp
+++ b/include/snbmodules/readout/SNBDataHandlingModel.hpp
@@ -9,19 +9,19 @@
 #ifndef SNBMODULES_INCLUDE_SNBMODULES_READOUT_SNBDATAHANDLINGMODEL_HPP_
 #define SNBMODULES_INCLUDE_SNBMODULES_READOUT_SNBDATAHANDLINGMODEL_HPP_
 
-#include "confmodel/DaqModule.hpp"
-#include "confmodel/Connection.hpp"
-#include "appmodel/DataHandlerModule.hpp"
 #include "appmodel/DataHandlerConf.hpp"
-#include "appmodel/RequestHandler.hpp"
-#include "appmodel/LatencyBuffer.hpp"
+#include "appmodel/DataHandlerModule.hpp"
 #include "appmodel/DataProcessor.hpp"
+#include "appmodel/LatencyBuffer.hpp"
+#include "appmodel/RequestHandler.hpp"
+#include "confmodel/Connection.hpp"
+#include "confmodel/DaqModule.hpp"
 
 #include "datahandlinglibs/opmon/datahandling_info.pb.h"
 
 #include "iomanager/IOManager.hpp"
-#include "iomanager/Sender.hpp"
 #include "iomanager/Receiver.hpp"
+#include "iomanager/Sender.hpp"
 
 #include "logging/Logging.hpp"
 
@@ -31,9 +31,9 @@
 #include "dfmessages/DataRequest.hpp"
 #include "dfmessages/TimeSync.hpp"
 
+#include "appmodel/DataHandlerModule.hpp"
 #include "datahandlinglibs/ReadoutLogging.hpp"
 #include "datahandlinglibs/concepts/DataHandlingConcept.hpp"
-#include "appmodel/DataHandlerModule.hpp"
 
 #include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
 #include "datahandlinglibs/FrameErrorRegistry.hpp"
@@ -63,7 +63,11 @@ using dunedaq::datahandlinglibs::logging::TLVL_WORK_STEPS;
 namespace dunedaq {
 namespace snbmodules {
 
-template<class ReadoutType, class RequestHandlerType, class LatencyBufferType, class RawDataProcessorType, class InputDataType = ReadoutType>
+template<class ReadoutType,
+         class RequestHandlerType,
+         class LatencyBufferType,
+         class RawDataProcessorType,
+         class InputDataType = ReadoutType>
 class SNBDataHandlingModel : public datahandlinglibs::DataHandlingConcept
 {
 public:
@@ -120,22 +124,18 @@ public:
   void stop(const appfwk::DAQModule::CommandData_t& args);
 
   // Record function: invokes request handler's record implementation
-  void record(const appfwk::DAQModule::CommandData_t& args) override 
-  { 
-    m_request_handler_impl->record(args); 
-  }
+  void record(const appfwk::DAQModule::CommandData_t& args) override { m_request_handler_impl->record(args); }
 
   // Opmon get_info call implementation
-  //void get_info(opmonlib::InfoCollector& ci, int level);
+  // void get_info(opmonlib::InfoCollector& ci, int level);
 
   // Consume callback
   std::function<void(IDT&&)> m_consume_callback;
 
 protected:
-
   // Perform processing operations on payload
   void process_item(RDT&& payload);
-  
+
   // Transform payload if needed, then perform processing
   void transform_and_process(IDT&& payload);
 
@@ -152,16 +152,13 @@ protected:
   void run_postprocess_scheduler();
 
   // Postprocess schedule coroutine
-  folly::coro::Task<void> postprocess_schedule();  
+  folly::coro::Task<void> postprocess_schedule();
 
   // Dispatch data request
   void dispatch_requests(dfmessages::DataRequest& data_request);
-  
+
   // Transform input data type to readout
-  virtual std::vector<RDT> transform_payload(IDT& original) const
-  {
-    return { reinterpret_cast<RDT&>(original) };
-  }
+  virtual std::vector<RDT> transform_payload(IDT& original) const { return { reinterpret_cast<RDT&>(original) }; }
 
   // Operational monitoring
   virtual void generate_opmon_data() override;
@@ -170,7 +167,7 @@ protected:
   std::atomic<bool>& m_run_marker;
 
   // CONFIGURATION
-  //appfwk::app::ModInit m_queue_config;
+  // appfwk::app::ModInit m_queue_config;
   bool m_callback_mode;
   bool m_fake_trigger;
   bool m_generate_timesync = false;
@@ -183,13 +180,16 @@ protected:
 
   // STATS
   using metric_t = dunedaq::datahandlinglibs::opmon::DataHandlerInfo;
-  using num_payload_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_payloads),metric_t>::type>::type;
-  using sum_payload_t = std::remove_const<std::invoke_result<decltype(&metric_t::sum_payloads),metric_t>::type>::type;
-  using num_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_requests),metric_t>::type>::type;
-  using sum_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::sum_requests),metric_t>::type>::type;
-  using rawq_timeout_count_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_data_input_timeouts),metric_t>::type>::type;
-  using num_lb_insert_failures_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures),metric_t>::type>::type;
-  using num_post_processing_delay_max_waits_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_post_processing_delay_max_waits),metric_t>::type>::type;
+  using num_payload_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_payloads), metric_t>::type>::type;
+  using sum_payload_t = std::remove_const<std::invoke_result<decltype(&metric_t::sum_payloads), metric_t>::type>::type;
+  using num_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::num_requests), metric_t>::type>::type;
+  using sum_request_t = std::remove_const<std::invoke_result<decltype(&metric_t::sum_requests), metric_t>::type>::type;
+  using rawq_timeout_count_t =
+    std::remove_const<std::invoke_result<decltype(&metric_t::num_data_input_timeouts), metric_t>::type>::type;
+  using num_lb_insert_failures_t =
+    std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures), metric_t>::type>::type;
+  using num_post_processing_delay_max_waits_t = std::remove_const<
+    std::invoke_result<decltype(&metric_t::num_post_processing_delay_max_waits), metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
   std::atomic<sum_payload_t> m_sum_payloads{ 0 };
@@ -215,9 +215,9 @@ protected:
   std::shared_ptr<request_receiver_ct> m_data_request_receiver;
 
   // FRAGMENT SENDER
-  //std::chrono::milliseconds m_fragment_sender_timeout_ms;
-  //using fragment_sender_ct = iomanager::SenderConcept<std::pair<std::unique_ptr<daqdataformats::Fragment>, std::string>>;
-  //std::shared_ptr<fragment_sender_ct> m_fragment_sender;
+  // std::chrono::milliseconds m_fragment_sender_timeout_ms;
+  // using fragment_sender_ct = iomanager::SenderConcept<std::pair<std::unique_ptr<daqdataformats::Fragment>,
+  // std::string>>; std::shared_ptr<fragment_sender_ct> m_fragment_sender;
 
   // TIME-SYNC
   using timesync_sender_ct = iomanager::SenderConcept<dfmessages::TimeSync>; // no timeout -> published

--- a/include/snbmodules/readout/detail/SNBDataHandlingModel.hxx
+++ b/include/snbmodules/readout/detail/SNBDataHandlingModel.hxx
@@ -9,20 +9,19 @@ namespace dunedaq {
 namespace snbmodules {
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerModule* mcfg)
 {
   // Setup request queues
-  //setup_request_queues(mcfg);
+  // setup_request_queues(mcfg);
   try {
     for (auto input : mcfg->get_inputs()) {
       if (input->get_data_type() == "DataRequest") {
-        m_data_request_receiver = get_iom_receiver<dfmessages::DataRequest>(input->UID()) ;
-      }
-      else {
+        m_data_request_receiver = get_iom_receiver<dfmessages::DataRequest>(input->UID());
+      } else {
         m_raw_data_receiver_connection_name = input->UID();
         // Parse for prefix
-        std::string conn_name = input->UID(); 
+        std::string conn_name = input->UID();
         const char delim = '_';
         std::vector<std::string> words;
         std::size_t start;
@@ -32,10 +31,10 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerM
           words.push_back(conn_name.substr(start, end - start));
         }
 
-	TLOG_DEBUG(TLVL_WORK_STEPS) << "Initialize connection based on uid: " 
-          << m_raw_data_receiver_connection_name << " front word: " << words.front();
+        TLOG_DEBUG(TLVL_WORK_STEPS) << "Initialize connection based on uid: " << m_raw_data_receiver_connection_name
+                                    << " front word: " << words.front();
 
-	std::string cb_prefix("cb");
+        std::string cb_prefix("cb");
         if (words.front() == cb_prefix) {
           m_callback_mode = true;
         }
@@ -49,7 +48,7 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerM
     for (auto output : mcfg->get_outputs()) {
       if (output->get_data_type() == "TimeSync") {
         m_generate_timesync = true;
-        m_timesync_sender = get_iom_sender<dfmessages::TimeSync>(output->UID()) ;
+        m_timesync_sender = get_iom_sender<dfmessages::TimeSync>(output->UID());
         m_timesync_connection_name = output->UID();
         break;
       }
@@ -74,8 +73,8 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerM
   register_node(mcfg->get_module_configuration()->get_data_processor()->UID(), m_raw_processor_impl);
   register_node(mcfg->get_module_configuration()->get_request_handler()->UID(), m_request_handler_impl);
 
-  //m_request_handler_impl->init(args);
-  //m_raw_processor_impl->init(args);
+  // m_request_handler_impl->init(args);
+  // m_raw_processor_impl->init(args);
   m_request_handler_supports_cutoff_timestamp = m_request_handler_impl->supports_cutoff_timestamp();
   m_fake_trigger = false;
   m_raw_receiver_sleep_us = std::chrono::microseconds::zero();
@@ -84,7 +83,6 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerM
   m_processing_delay_ticks = mcfg->get_module_configuration()->get_post_processing_delay_ticks();
   m_post_processing_delay_min_wait = mcfg->get_module_configuration()->get_post_processing_delay_min_wait();
   m_post_processing_delay_max_wait = mcfg->get_module_configuration()->get_post_processing_delay_max_wait();
-  
 
   // Configure implementations:
   m_raw_processor_impl->conf(mcfg);
@@ -100,14 +98,15 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerM
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::conf(const appfwk::DAQModule::CommandData_t& /*args*/)
 {
   // Register callbacks if operating in that mode.
   if (m_callback_mode) {
     // Configure and register consume callback
-    m_consume_callback = std::bind(&SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_callback, this, std::placeholders::_1);
- 
+    m_consume_callback =
+      std::bind(&SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_callback, this, std::placeholders::_1);
+
     // Register callback
     auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
     dmcbr->register_callback<IDT>(m_raw_data_receiver_connection_name, m_consume_callback);
@@ -121,12 +120,11 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::conf(const appfwk::DAQModule::Com
   if (m_processing_delay_ticks) {
     m_postprocess_scheduler_thread.set_name("pprocsched", m_sourceid.id);
     m_timekeeper = std::make_unique<folly::ThreadWheelTimekeeper>();
-  }  
+  }
 }
 
-
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const appfwk::DAQModule::CommandData_t& args)
 {
   // Reset opmon variables
@@ -153,15 +151,16 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const appfwk::DAQModule::Co
     m_timesync_thread.set_work(&SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync, this);
   }
   if (m_processing_delay_ticks) {
-    m_postprocess_scheduler_thread.set_work(&SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_postprocess_scheduler, this);
-  }  
+    m_postprocess_scheduler_thread.set_work(&SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_postprocess_scheduler,
+                                            this);
+  }
   // Register callback to receive and dispatch data requests
   m_data_request_receiver->add_callback(
     std::bind(&SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::dispatch_requests, this, std::placeholders::_1));
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::stop(const appfwk::DAQModule::CommandData_t& args)
 {
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Stoppping threads...";
@@ -184,8 +183,8 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::stop(const appfwk::DAQModule::Com
     m_baton.post(); // In case the coroutine is still waiting when the consumer has stopped
     while (!m_postprocess_scheduler_thread.get_readiness()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }  
-  }  
+    }
+  }
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Flushing latency buffer with occupancy: " << m_latency_buffer_impl->occupancy();
   m_latency_buffer_impl->flush();
   m_raw_processor_impl->stop(args);
@@ -193,80 +192,84 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::stop(const appfwk::DAQModule::Com
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
- {
+{
   datahandlinglibs::opmon::DataHandlerInfo ri;
-   ri.set_sum_payloads(m_sum_payloads.load());
-   ri.set_num_payloads(m_num_payloads.exchange(0));
+  ri.set_sum_payloads(m_sum_payloads.load());
+  ri.set_num_payloads(m_num_payloads.exchange(0));
 
-   ri.set_num_data_input_timeouts(m_rawq_timeout_count.exchange(0));
+  ri.set_num_data_input_timeouts(m_rawq_timeout_count.exchange(0));
 
-   auto now = std::chrono::high_resolution_clock::now();
-   int new_packets = m_stats_packet_count.exchange(0);
-   double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
-   m_t0 = now;
+  auto now = std::chrono::high_resolution_clock::now();
+  int new_packets = m_stats_packet_count.exchange(0);
+  double seconds = std::chrono::duration_cast<std::chrono::microseconds>(now - m_t0).count() / 1000000.;
+  m_t0 = now;
 
-   // 08-May-2025, KAB: added a message to warn users when latency buffer inserts are failing.
-   int local_num_lb_insert_failures = m_num_lb_insert_failures.exchange(0);
-   if (local_num_lb_insert_failures != 0) {
-     ers::warning(datahandlinglibs::NonZeroLatencyBufferInsertFailures(
-       ERS_HERE, m_sourceid, local_num_lb_insert_failures, ri.num_payloads()));
-   }
+  // 08-May-2025, KAB: added a message to warn users when latency buffer inserts are failing.
+  int local_num_lb_insert_failures = m_num_lb_insert_failures.exchange(0);
+  if (local_num_lb_insert_failures != 0) {
+    ers::warning(datahandlinglibs::NonZeroLatencyBufferInsertFailures(
+      ERS_HERE, m_sourceid, local_num_lb_insert_failures, ri.num_payloads()));
+  }
 
-   ri.set_rate_payloads_consumed(new_packets / seconds / 1000.);
-   ri.set_num_lb_insert_failures(local_num_lb_insert_failures);
-   ri.set_sum_requests(m_sum_requests.load());
-   ri.set_num_requests(m_num_requests.exchange(0));
-   ri.set_num_post_processing_delay_max_waits(m_num_post_processing_delay_max_waits.exchange(0));
-   ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
-   ri.set_newest_timestamp(m_raw_processor_impl->get_last_daq_time());
-   ri.set_oldest_timestamp(m_request_handler_impl->get_oldest_time());
+  ri.set_rate_payloads_consumed(new_packets / seconds / 1000.);
+  ri.set_num_lb_insert_failures(local_num_lb_insert_failures);
+  ri.set_sum_requests(m_sum_requests.load());
+  ri.set_num_requests(m_num_requests.exchange(0));
+  ri.set_num_post_processing_delay_max_waits(m_num_post_processing_delay_max_waits.exchange(0));
+  ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
+  ri.set_newest_timestamp(m_raw_processor_impl->get_last_daq_time());
+  ri.set_oldest_timestamp(m_request_handler_impl->get_oldest_time());
 
-   this->publish(std::move(ri));
- }
+  this->publish(std::move(ri));
+}
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 void
-SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::transform_and_process(IDT&& payload) {
+SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::transform_and_process(IDT&& payload)
+{
   if constexpr (std::is_same_v<IDT, RDT>) {
     process_item(std::move(payload));
   } else {
     auto transformed = transform_payload(payload);
     for (auto& i : transformed) {
       process_item(std::move(i));
-    }   
-  }  
+    }
+  }
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 void
-SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_callback(IDT&& payload) {
+SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::consume_callback(IDT&& payload)
+{
   transform_and_process(std::move(payload));
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
 {
   m_raw_processor_impl->preprocess_item(&payload);
   if (m_request_handler_supports_cutoff_timestamp) {
     int64_t diff1 = payload.get_timestamp() - m_request_handler_impl->get_cutoff_timestamp();
     if (diff1 <= 0) {
-      //m_request_handler_impl->increment_tardy_tp_count();
+      // m_request_handler_impl->increment_tardy_tp_count();
       ers::warning(datahandlinglibs::DataPacketArrivedTooLate(ERS_HERE,
                                                               m_sourceid,
                                                               m_run_number,
                                                               payload.get_timestamp(),
-                                            m_request_handler_impl->get_cutoff_timestamp(), diff1,
-                                            (static_cast<double>(diff1)/62500.0)));
+                                                              m_request_handler_impl->get_cutoff_timestamp(),
+                                                              diff1,
+                                                              (static_cast<double>(diff1) / 62500.0)));
     }
   }
   while (m_latency_buffer_impl->isFull()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   if (!m_latency_buffer_impl->write(std::move(payload))) {
-    // TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer insert failed! (Payload timestamp=" << payload.get_timestamp() << ")";
+    // TLOG_DEBUG(TLVL_TAKE_NOTE) << "***ERROR: Latency buffer insert failed! (Payload timestamp=" <<
+    // payload.get_timestamp() << ")";
     m_num_lb_insert_failures++;
     return;
   }
@@ -282,14 +285,14 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::process_item(RDT&& payload)
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_postprocess_scheduler()
 {
   folly::coro::blockingWait(postprocess_schedule());
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
 {
 
@@ -311,7 +314,7 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
     } else {
       ++m_rawq_timeout_count;
       // Protection against a zero sleep becoming a yield
-      if ( m_raw_receiver_sleep_us != std::chrono::microseconds::zero())
+      if (m_raw_receiver_sleep_us != std::chrono::microseconds::zero())
         std::this_thread::sleep_for(m_raw_receiver_sleep_us);
     }
   }
@@ -320,7 +323,8 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_consume()
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
 folly::coro::Task<void>
-SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {  
+SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
+{
 
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Postprocess schedule coroutine started...";
   timestamp_t newest_ts = 0;
@@ -332,13 +336,12 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {
   RDT processed_element;
 
   // Deferral of the post processing, to allow elements being reordered in the LB
-  // Basically, find data older than a certain timestamp and process all data since the last post-processed element up to that value  
+  // Basically, find data older than a certain timestamp and process all data since the last post-processed element up
+  // to that value
   while (m_run_marker.load()) {
     try {
       co_await folly::coro::timeout(
-        m_baton.operator co_await(),
-        std::chrono::milliseconds{m_post_processing_delay_max_wait},
-        m_timekeeper.get());
+        m_baton.operator co_await(), std::chrono::milliseconds{ m_post_processing_delay_max_wait }, m_timekeeper.get());
       m_baton.reset();
     } catch (const folly::FutureTimeout&) {
       ++m_num_post_processing_delay_max_waits;
@@ -385,7 +388,7 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule() {
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync()
 {
   TLOG_DEBUG(TLVL_WORK_STEPS) << "TimeSync thread started...";
@@ -410,16 +413,17 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync()
         timesyncmsg.sequence_number = ++msg_seqno;
         timesyncmsg.source_id = m_sourceid.id;
         TLOG_DEBUG(TLVL_TIME_SYNCS) << "New timesync: daq=" << timesyncmsg.daq_time
-          << " wall=" << timesyncmsg.system_time << " run=" << timesyncmsg.run_number
-          << " seqno=" << timesyncmsg.sequence_number << " source_id=" << timesyncmsg.source_id;
+                                    << " wall=" << timesyncmsg.system_time << " run=" << timesyncmsg.run_number
+                                    << " seqno=" << timesyncmsg.sequence_number
+                                    << " source_id=" << timesyncmsg.source_id;
         try {
-            dfmessages::TimeSync timesyncmsg_copy(timesyncmsg);
+          dfmessages::TimeSync timesyncmsg_copy(timesyncmsg);
           m_timesync_sender->send(std::move(timesyncmsg_copy), std::chrono::milliseconds(500));
         } catch (ers::Issue& excpt) {
           ers::warning(
             datahandlinglibs::TimeSyncTransmissionFailed(ERS_HERE, m_sourceid, m_timesync_connection_name, excpt));
         }
-          
+
         if (m_fake_trigger) {
           dfmessages::DataRequest dr;
           ++m_current_fake_trigger_id;
@@ -431,18 +435,21 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync()
           dr.request_information.window_end = dr.request_information.window_begin + width;
           dr.request_information.component = m_sourceid;
           dr.data_destination = "data_fragments_q";
-          TLOG_DEBUG(TLVL_WORK_STEPS) << "Issuing fake trigger based on timesync. "
-            << " ts=" << dr.trigger_timestamp 
-            << " window_begin=" << dr.request_information.window_begin
-            << " window_end=" << dr.request_information.window_end;
+          TLOG_DEBUG(TLVL_WORK_STEPS) << "Issuing fake trigger based on timesync. " << " ts=" << dr.trigger_timestamp
+                                      << " window_begin=" << dr.request_information.window_begin
+                                      << " window_end=" << dr.request_information.window_end;
           m_request_handler_impl->issue_request(dr);
 
           ++m_num_requests;
           ++m_sum_requests;
         }
       } else {
-        if (timesyncmsg.daq_time == 0) {++zero_timestamp_count;}
-        if (timesyncmsg.daq_time == prev_timestamp) {++duplicate_timestamp_count;}
+        if (timesyncmsg.daq_time == 0) {
+          ++zero_timestamp_count;
+        }
+        if (timesyncmsg.daq_time == prev_timestamp) {
+          ++duplicate_timestamp_count;
+        }
         if (once_per_run) {
           TLOG() << "Timesync with DAQ time 0 won't be sent out as it's an invalid sync.";
           once_per_run = false;
@@ -452,7 +459,7 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync()
       // ++m_timesyncqueue_timeout;
     }
     // Split up the 100ms sleep into 10 sleeps of 10ms, so we respond to "stop" quicker
-    for (size_t i=0; i<10; ++i) {
+    for (size_t i = 0; i < 10; ++i) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
       if (!m_run_marker.load()) {
         break;
@@ -466,21 +473,21 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::run_timesync()
 }
 
 template<class RDT, class RHT, class LBT, class RPT, class IDT>
-void 
+void
 SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::dispatch_requests(dfmessages::DataRequest& data_request)
 {
   if (data_request.request_information.component != m_sourceid) {
-     ers::error(datahandlinglibs::RequestSourceIDMismatch(ERS_HERE, m_sourceid, data_request.request_information.component));
-     return;
+    ers::error(
+      datahandlinglibs::RequestSourceIDMismatch(ERS_HERE, m_sourceid, data_request.request_information.component));
+    return;
   }
-  TLOG_DEBUG(TLVL_QUEUE_POP) << "Received DataRequest" 
-    << " for trig/seq_number " << data_request.trigger_number << "." << data_request.sequence_number
-    << ", runno " << data_request.run_number
-    << ", trig timestamp " << data_request.trigger_timestamp
-    << ", SourceID: " << data_request.request_information.component
-    << ", window begin/end " << data_request.request_information.window_begin
-    << "/" << data_request.request_information.window_end
-    << ", dest: " << data_request.data_destination;
+  TLOG_DEBUG(TLVL_QUEUE_POP) << "Received DataRequest" << " for trig/seq_number " << data_request.trigger_number << "."
+                             << data_request.sequence_number << ", runno " << data_request.run_number
+                             << ", trig timestamp " << data_request.trigger_timestamp
+                             << ", SourceID: " << data_request.request_information.component << ", window begin/end "
+                             << data_request.request_information.window_begin << "/"
+                             << data_request.request_information.window_end
+                             << ", dest: " << data_request.data_destination;
   m_request_handler_impl->issue_request(data_request);
   ++m_num_requests;
   ++m_sum_requests;

--- a/include/snbmodules/readout/detail/SNBRequestHandlerModel.hxx
+++ b/include/snbmodules/readout/detail/SNBRequestHandlerModel.hxx
@@ -185,6 +185,7 @@ SNBRequestHandlerModel<RDT, LBT>::issue_request(dfmessages::DataRequest datarequ
         // Send fragment
         get_iom_sender<std::unique_ptr<daqdataformats::Fragment>>(datarequest.data_destination)
           ->send(std::move(result.fragment), std::chrono::milliseconds(m_fragment_send_timeout_ms));
+        cleanup_check();
 
       } catch (const ers::Issue& excpt) {
         ers::warning(datahandlinglibs::CannotWriteToQueue(ERS_HERE, m_sourceid, datarequest.data_destination, excpt));
@@ -300,6 +301,9 @@ SNBRequestHandlerModel<RDT, LBT>::cleanup()
   unsigned popped = 0;
   {
     std::lock_guard<std::mutex> lk(m_pop_list_mutex);
+    // TLOG_DEBUG(TLVL_HOUSEKEEPING) << "Cleanup requested, there are " << m_pop_list.size()
+    //                               << " entries in the cleanup list, first TS=" << *m_pop_list.begin()
+    //                               << ", buffer TS=" << m_latency_buffer->front()->get_timestamp();
     while (!m_pop_list.empty() && m_latency_buffer->occupancy() > 1) {
       auto ts = m_latency_buffer->front()->get_timestamp();
       if (m_pop_list.count(ts)) {
@@ -382,7 +386,7 @@ SNBRequestHandlerModel<RDT, LBT>::get_fragment_pieces(uint64_t start_win_ts, uin
   uint64_t last_ts = front_element->get_timestamp();  // NOLINT(build/unsigned)
   uint64_t newest_ts = last_element->get_timestamp(); // NOLINT(build/unsigned)
 
-  if (start_win_ts > newest_ts) {
+  if (start_win_ts > newest_ts || newest_ts < end_win_ts) {
     // No element is as small as the start window-> request is far in the future
     rres.result_code = ResultCode::kNotYet; // give it another chance
   } else if (end_win_ts <= last_ts) {
@@ -402,7 +406,7 @@ SNBRequestHandlerModel<RDT, LBT>::get_fragment_pieces(uint64_t start_win_ts, uin
                                   << ", --> distance from window: "
                                   << int64_t(start_win_ts) - int64_t(start_iter->get_timestamp());
 
-        rres.result_code = ResultCode::kFound;
+      rres.result_code = ResultCode::kFound;
 
       auto elements_handled = 0;
 
@@ -410,18 +414,17 @@ SNBRequestHandlerModel<RDT, LBT>::get_fragment_pieces(uint64_t start_win_ts, uin
 
       while (start_iter.good() && element->get_timestamp() <= end_win_ts) {
         std::lock_guard<std::mutex> lk(m_pop_list_mutex);
-        if (m_pop_list.count(element->get_timestamp()) ) {
+        if (m_pop_list.count(element->get_timestamp())) {
           TLOG_DEBUG(50) << "skip processing for current element " << element->get_timestamp()
                          << ", already included in trigger.";
-        }
-        else if (element->get_timestamp() < start_win_ts) {
-          TLOG_DEBUG(50) << "skip processing for current element " << element->get_timestamp()
+        } else if (element->get_timestamp() < start_win_ts) {
+          TLOG_DEBUG(51) << "skip processing for current element " << element->get_timestamp()
                          << ", out of readout window.";
         }
 
         else {
-          // TLOG_DEBUG(50) << "Add element " << element->get_timestamp();
-          //  SNB mode, the whole aggregated object (e.g.: superchunk) can be copied
+          // TLOG_DEBUG(52) << "Add element " << element->get_timestamp();
+          //   SNB mode, the whole aggregated object (e.g.: superchunk) can be copied
           frag_pieces.emplace_back(
             std::make_pair<void*, size_t>(static_cast<void*>((*start_iter).begin()), element->get_payload_size()));
 
@@ -467,11 +470,11 @@ SNBRequestHandlerModel<RDT, LBT>::data_request(dfmessages::DataRequest dr)
     uint64_t newest_ts = last_element->get_timestamp(); // NOLINT(build/unsigned)
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Data request for trig/seq_num=" << dr.trigger_number << "." << dr.sequence_number
                                 << " and SourceID[" << m_sourceid << "] with" << " Trigger TS=" << dr.trigger_timestamp
-                                << " Oldest stored TS=" << last_ts << " Newest stored TS=" << newest_ts
                                 << " Start of window TS=" << dr.request_information.window_begin
-                                << " End of window TS=" << dr.request_information.window_end
-                                << " Latency buffer occupancy=" << m_latency_buffer->occupancy()
-                                << " frag_pieces result_code=" << rres.result_code
+                                << " End of window TS=" << dr.request_information.window_end;
+    TLOG_DEBUG(TLVL_WORK_STEPS) << " Oldest stored TS=" << last_ts << " Newest stored TS=" << newest_ts
+                                << " Latency buffer occupancy=" << m_latency_buffer->occupancy();
+    TLOG_DEBUG(TLVL_WORK_STEPS) << " frag_pieces result_code=" << rres.result_code
                                 << " number of frag_pieces=" << frag_pieces.size();
 
     switch (rres.result_code) {

--- a/plugins/SNBDataHandlerModule.cpp
+++ b/plugins/SNBDataHandlerModule.cpp
@@ -17,8 +17,8 @@
 #include "datahandlinglibs/DataHandlingIssues.hpp"
 #include "datahandlinglibs/ReadoutLogging.hpp"
 #include "datahandlinglibs/concepts/DataHandlingConcept.hpp"
-#include "snbmodules/readout/SNBDataHandlingModel.hpp"
 #include "datahandlinglibs/models/FixedRateQueueModel.hpp"
+#include "snbmodules/readout/SNBDataHandlingModel.hpp"
 
 #include "fdreadoutlibs/DAPHNEEthTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
@@ -147,10 +147,10 @@ SNBDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf,
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a PDS DAPHNE using SkipList LB";
     auto readout_model = std::make_shared<
       SNBDataHandlingModel<fdt::DAPHNESuperChunkTypeAdapter,
-                             SNBRequestHandlerModel<fdt::DAPHNESuperChunkTypeAdapter,
-                                                    rol::FixedRateQueueModel<fdt::DAPHNESuperChunkTypeAdapter>>,
-                             rol::FixedRateQueueModel<fdt::DAPHNESuperChunkTypeAdapter>,
-                             fdl::DAPHNEFrameProcessor>>(run_marker);
+                           SNBRequestHandlerModel<fdt::DAPHNESuperChunkTypeAdapter,
+                                                  rol::FixedRateQueueModel<fdt::DAPHNESuperChunkTypeAdapter>>,
+                           rol::FixedRateQueueModel<fdt::DAPHNESuperChunkTypeAdapter>,
+                           fdl::DAPHNEFrameProcessor>>(run_marker);
     register_node("PDSFrameProcessor", readout_model);
     readout_model->init(modconf);
     return readout_model;
@@ -174,10 +174,10 @@ SNBDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf,
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a PDS DAPHNE stream mode using BinarySearchQueue LB";
     auto readout_model = std::make_shared<
       SNBDataHandlingModel<fdt::DAPHNEStreamSuperChunkTypeAdapter,
-                             SNBRequestHandlerModel<fdt::DAPHNEStreamSuperChunkTypeAdapter,
-                                                    rol::FixedRateQueueModel<fdt::DAPHNEStreamSuperChunkTypeAdapter>>,
-                             rol::FixedRateQueueModel<fdt::DAPHNEStreamSuperChunkTypeAdapter>,
-                             fdl::DAPHNEStreamFrameProcessor>>(run_marker);
+                           SNBRequestHandlerModel<fdt::DAPHNEStreamSuperChunkTypeAdapter,
+                                                  rol::FixedRateQueueModel<fdt::DAPHNEStreamSuperChunkTypeAdapter>>,
+                           rol::FixedRateQueueModel<fdt::DAPHNEStreamSuperChunkTypeAdapter>,
+                           fdl::DAPHNEStreamFrameProcessor>>(run_marker);
     register_node("PDSStreamFrameProcessor", readout_model);
     readout_model->init(modconf);
     return readout_model;


### PR DESCRIPTION
# Description

Adds a check that the end of the request window is in the latency buffer before returning Fragment pieces. This helps when requests are coming in faster than the file is being read by the data source, which can lead to a Fragment missing a piece of the data, which then in turn prevents the latency buffer from being drained.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] simple_transform_test passes with 22GB input file

## Further checks

- [x] dbt-clang-format.sh run over code
