### PR TITLE
Use DataMoveCallbackRegistry to move data from FileReaderSource

### DIFF
--- a/include/snbmodules/readout/FileReaderBase.hpp
+++ b/include/snbmodules/readout/FileReaderBase.hpp
@@ -17,6 +17,7 @@
 
 #include "appmodel/DataReaderConf.hpp"
 #include "appmodel/DataReaderModule.hpp"
+#include "appmodel/DataMoveCallbackConf.hpp"
 #include "confmodel/Connection.hpp"
 #include "confmodel/DaqModule.hpp"
 #include "confmodel/DetDataSender.hpp"
@@ -60,7 +61,7 @@ public:
   void init(std::shared_ptr<appfwk::ConfigurationManager> cfg);
 
   // To be implemented by final module
-  virtual std::shared_ptr<snbmodules::FileSourceConcept> create_source_emulator(std::string qi,
+  virtual std::shared_ptr<snbmodules::FileSourceConcept> create_source_emulator(const appmodel::DataMoveCallbackConf* cb_conf,
                                                                                 std::atomic<bool>& run_marker) = 0;
 
   // Commands

--- a/include/snbmodules/readout/FileSourceConcept.hpp
+++ b/include/snbmodules/readout/FileSourceConcept.hpp
@@ -13,6 +13,7 @@
 #include "confmodel/DetectorStream.hpp"
 #include "datahandlinglibs/utils/RateLimiter.hpp"
 #include "opmonlib/MonitorableObject.hpp"
+#include "appmodel/DataMoveCallbackConf.hpp"
 
 #include <map>
 #include <string>
@@ -32,7 +33,7 @@ public:
   FileSourceConcept(FileSourceConcept&&) = delete;                 ///< FileSourceConcept is not move-constructible
   FileSourceConcept& operator=(FileSourceConcept&&) = delete;      ///< FileSourceConcept is not move-assignable
 
-  virtual void set_sender(const std::string& /*sink_name*/) = 0;
+  virtual void set_sender(const appmodel::DataMoveCallbackConf* /*sink_name*/) = 0;
   virtual void conf(const confmodel::DetectorStream* conf, const appmodel::SNBFileSourceParameters* emu_conf) = 0;
   virtual void start(const appfwk::DAQModule::CommandData_t& /*args*/) = 0;
   virtual void stop(const appfwk::DAQModule::CommandData_t& /*args*/) = 0;

--- a/include/snbmodules/readout/FileSourceModel.hpp
+++ b/include/snbmodules/readout/FileSourceModel.hpp
@@ -20,6 +20,7 @@
 #include "datahandlinglibs/utils/BufferedFileReader.hpp"
 #include "datahandlinglibs/utils/RateLimiter.hpp"
 #include "snbmodules/readout/FileSourceConcept.hpp"
+#include "appmodel/DataMoveCallbackConf.hpp"
 #include "utilities/ReusableThread.hpp"
 
 #include "datahandlinglibs/opmon/datahandling_info.pb.h"
@@ -49,13 +50,12 @@ public:
     , m_rate_khz(rate_khz)
     , m_packet_count{ 0 }
     , m_raw_sender_timeout_ms(0)
-    , m_raw_data_sender(nullptr)
     , m_producer_thread(0)
   {
   }
 
   // void init(const appfwk::DAQModule::CommandData_t& /*args*/) {}
-  void set_sender(const std::string& conn_name);
+  void set_sender(const appmodel::DataMoveCallbackConf* sink);
 
   void conf(const confmodel::DetectorStream* stream_conf, const appmodel::SNBFileSourceParameters* file_params);
   void scrap(const appfwk::DAQModule::CommandData_t& /*args*/)
@@ -103,10 +103,8 @@ private:
 
   // RAW SENDER
   std::chrono::milliseconds m_raw_sender_timeout_ms;
-  using raw_sender_ct = iomanager::SenderConcept<ReadoutType>;
-  std::shared_ptr<raw_sender_ct> m_raw_data_sender;
-
-  bool m_sender_is_set = false;
+  const appmodel::DataMoveCallbackConf* m_raw_sender_conf{ nullptr };
+  std::shared_ptr<std::function<void(ReadoutType&&)>> m_raw_data_callback{ nullptr };
   // using module_conf_t = dunedaq::snbmodules::sourceemulatorconfig::Conf;
   // module_conf_t m_conf;
   // using link_conf_t = dunedaq::snbmodules::sourceemulatorconfig::LinkConfiguration;

--- a/include/snbmodules/readout/detail/FileReaderBase.hxx
+++ b/include/snbmodules/readout/detail/FileReaderBase.hxx
@@ -1,6 +1,7 @@
 
 #include "datahandlinglibs/DataHandlingIssues.hpp"
 #include "datahandlinglibs/ReadoutLogging.hpp"
+#include "appmodel/DataMoveCallbackConf.hpp"
 
 namespace dunedaq {
 namespace snbmodules {
@@ -22,22 +23,21 @@ FileReaderBase::init(std::shared_ptr<appfwk::ConfigurationManager> cfg)
   auto ini = cfg->get_dal<appmodel::DataReaderModule>(m_name);
   if (ini != nullptr && ini->get_configuration()->get_emulation_mode()) {
 
-    for (auto qi : ini->get_outputs()) {
+    for (auto cb : ini->get_raw_data_callbacks()) {
 
       try {
-        if (m_source_emus.find(qi->UID()) != m_source_emus.end()) {
+        if (m_source_emus.find(cb->UID()) != m_source_emus.end()) {
           TLOG() << get_fcr_name() << "Same queue instance used twice";
           throw datahandlinglibs::FailedFakeCardInitialization(ERS_HERE, get_fcr_name(), "");
         }
-        m_source_emus[qi->UID()] = create_source_emulator(qi->UID(), m_run_marker);
-        if (m_source_emus[qi->UID()].get() == nullptr) {
+        m_source_emus[cb->UID()] = create_source_emulator(cb, m_run_marker);
+        if (m_source_emus[cb->UID()].get() == nullptr) {
           TLOG() << get_fcr_name() << "Source emulator could not be created";
           throw datahandlinglibs::FailedFakeCardInitialization(ERS_HERE, get_fcr_name(), "");
         }
         // m_source_emus[qi->UID()]->init(cfg);
-        m_source_emus[qi->UID()]->set_sender(qi->UID());
       } catch (const ers::Issue& excpt) {
-        throw datahandlinglibs::ResourceQueueError(ERS_HERE, qi->UID(), get_fcr_name(), excpt);
+        throw datahandlinglibs::ResourceQueueError(ERS_HERE, cb->UID(), get_fcr_name(), excpt);
       }
     }
   }
@@ -64,21 +64,17 @@ FileReaderBase::do_conf(const appfwk::DAQModule::CommandData_t& /*args*/)
       }
     }
 
-    for (const auto& qi : cfg->get_outputs()) {
-      auto q_with_id = qi->cast<confmodel::QueueWithSourceId>();
-      if (q_with_id == nullptr) {
-        throw datahandlinglibs::FailedFakeCardInitialization(
-          ERS_HERE, get_fcr_name(), "Queue is not of type QueueWithSourceId");
+    for (const auto& cb : cfg->get_raw_data_callbacks()) {
+      if (m_source_emus.find(cb->UID()) == m_source_emus.end()) {
+        TLOG() << "Cannot find queue: " << cb->UID() << std::endl;
+        throw datahandlinglibs::GenericConfigurationError(ERS_HERE, "Cannot find queue: " + cb->UID());
       }
-      if (m_source_emus.find(q_with_id->UID()) == m_source_emus.end()) {
-        TLOG() << "Cannot find queue: " << q_with_id->UID() << std::endl;
-        throw datahandlinglibs::GenericConfigurationError(ERS_HERE, "Cannot find queue: " + q_with_id->UID());
+      if (m_source_emus[cb->UID()]->is_configured()) {
+        TLOG() << "Emulator for queue name " << cb->UID() << " was already configured";
+        throw datahandlinglibs::GenericConfigurationError(ERS_HERE, "Emulator configured twice: " + cb->UID());
       }
-      if (m_source_emus[q_with_id->UID()]->is_configured()) {
-        TLOG() << "Emulator for queue name " << q_with_id->UID() << " was already configured";
-        throw datahandlinglibs::GenericConfigurationError(ERS_HERE, "Emulator configured twice: " + q_with_id->UID());
-      }
-      m_source_emus[q_with_id->UID()]->conf(streams[q_with_id->get_source_id()],
+      m_source_emus[cb->UID()]->set_sender(cb);
+      m_source_emus[cb->UID()]->conf(streams[cb->get_source_id()],
                                             cfg->get_configuration()->get_snb_conf());
     }
     for (auto& [name, emu] : m_source_emus) {

--- a/include/snbmodules/readout/detail/FileSourceModel.hxx
+++ b/include/snbmodules/readout/detail/FileSourceModel.hxx
@@ -2,6 +2,7 @@
 
 #include "datahandlinglibs/DataHandlingIssues.hpp"
 #include "datahandlinglibs/ReadoutLogging.hpp"
+#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
 
 using dunedaq::datahandlinglibs::CannotWriteToQueue;
 using dunedaq::datahandlinglibs::ConfigurationError;
@@ -14,14 +15,9 @@ namespace snbmodules {
 
 template<class ReadoutType>
 void
-FileSourceModel<ReadoutType>::set_sender(const std::string& conn_name)
+FileSourceModel<ReadoutType>::set_sender(const appmodel::DataMoveCallbackConf* sink)
 {
-  if (!m_sender_is_set) {
-    m_raw_data_sender = get_iom_sender<ReadoutType>(conn_name);
-    m_sender_is_set = true;
-  } else {
-    // ers::error();
-  }
+  m_raw_sender_conf = sink;
 }
 
 template<class ReadoutType>
@@ -132,11 +128,17 @@ FileSourceModel<ReadoutType>::run_produce()
     TLOG_DEBUG(TLVL_BOOKKEEPING) << "Read element with timestamp " << elem.get_timestamp() << " from file";
 
     // send it
-    bool send_successful = false;
-    while (!send_successful && m_run_marker.load()) {
-      ReadoutType elem_copy(elem);
-      send_successful = m_raw_data_sender->try_send(std::move(elem_copy), m_raw_sender_timeout_ms);
+    while (m_raw_data_callback == nullptr && m_run_marker.load()) {
+      m_raw_data_callback =
+        datahandlinglibs::DataMoveCallbackRegistry::get()->get_callback<ReadoutType>(m_raw_sender_conf);
+      TLOG_DEBUG(TLVL_WORK_STEPS) << "Sender not set yet, waiting...";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
+
+    if (!m_run_marker.load()) {
+      break;
+    }
+    (*m_raw_data_callback)(std::move(elem));
 
     // Count packet and limit rate if needed.
     ++m_packet_count;

--- a/plugins/SNBFileReaderModule.cpp
+++ b/plugins/SNBFileReaderModule.cpp
@@ -68,7 +68,7 @@ SNBFileReaderModule::init(std::shared_ptr<appfwk::ConfigurationManager> cfg)
 }
 
 std::shared_ptr<snbmodules::FileSourceConcept>
-SNBFileReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& run_marker)
+SNBFileReaderModule::create_source_emulator(const appmodel::DataMoveCallbackConf* cb_conf, std::atomic<bool>& run_marker)
 {
   //! Values suitable to emulation
 
@@ -89,21 +89,17 @@ SNBFileReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>&
   static constexpr double crtbern_rate_khz = 100;
   static constexpr double crtgrenoble_rate_khz = 100;
 
-  auto datatypes = dunedaq::iomanager::IOManager::get()->get_datatypes(q_id);
-  if (datatypes.size() != 1) {
-    ers::error(dunedaq::datahandlinglibs::GenericConfigurationError(
-      ERS_HERE, "Multiple output data types specified! Expected only a single type!"));
-  }
-  std::string raw_dt{ *datatypes.begin() };
-  TLOG() << "Choosing specialization for SourceEmulator with raw_input" << " [uid:" << q_id << " , data_type:" << raw_dt
+  std::string raw_dt = cb_conf->get_data_type();
+  TLOG() << "Choosing specialization for SourceEmulator with raw_input" << " [uid:" << cb_conf->UID()
+         << " , data_type:" << raw_dt
          << ']';
 
   // IF WIBETH
   if (raw_dt.find("WIBEthFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake wibeth link";
     auto source_emu_model = std::make_shared<snbmodules::FileSourceModel<fdreadoutlibs::types::DUNEWIBEthTypeAdapter>>(
-      q_id, run_marker, wibeth_rate_khz);
-    register_node(q_id, source_emu_model);
+      cb_conf->UID(), run_marker, wibeth_rate_khz);
+    register_node(cb_conf->UID(), source_emu_model);
     return source_emu_model;
   }
 
@@ -112,8 +108,8 @@ SNBFileReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>&
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds link";
     auto source_emu_model =
       std::make_shared<snbmodules::FileSourceModel<fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>>(
-        q_id, run_marker, daphne_rate_khz);
-    register_node(q_id, source_emu_model);
+        cb_conf->UID(), run_marker, daphne_rate_khz);
+    register_node(cb_conf->UID(), source_emu_model);
     return source_emu_model;
   }
 
@@ -122,8 +118,8 @@ SNBFileReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>&
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds stream link";
     auto source_emu_model =
       std::make_shared<snbmodules::FileSourceModel<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>>(
-        q_id, run_marker, daphnestream_rate_khz);
-    register_node(q_id, source_emu_model);
+        cb_conf->UID(), run_marker, daphnestream_rate_khz);
+    register_node(cb_conf->UID(), source_emu_model);
     return source_emu_model;
   }
 
@@ -131,8 +127,8 @@ SNBFileReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>&
   if (raw_dt.find("TDEEthFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake tde link";
     auto source_emu_model = std::make_shared<snbmodules::FileSourceModel<fdreadoutlibs::types::TDEEthTypeAdapter>>(
-      q_id, run_marker, tdeeth_rate_khz);
-    register_node(q_id, source_emu_model);
+      cb_conf->UID(), run_marker, tdeeth_rate_khz);
+    register_node(cb_conf->UID(), source_emu_model);
     return source_emu_model;
   }
 
@@ -140,8 +136,8 @@ SNBFileReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>&
   if (raw_dt.find("CRTBernFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake crt bern link";
     auto source_emu_model = std::make_shared<snbmodules::FileSourceModel<fdreadoutlibs::types::CRTBernTypeAdapter>>(
-      q_id, run_marker, crtbern_rate_khz);
-    register_node(q_id, source_emu_model);
+      cb_conf->UID(), run_marker, crtbern_rate_khz);
+    register_node(cb_conf->UID(), source_emu_model);
     return source_emu_model;
   }
 
@@ -149,8 +145,8 @@ SNBFileReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>&
   if (raw_dt.find("CRTGrenobleFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake crt grenoble link";
     auto source_emu_model = std::make_shared<snbmodules::FileSourceModel<fdreadoutlibs::types::CRTGrenobleTypeAdapter>>(
-      q_id, run_marker, crtgrenoble_rate_khz);
-    register_node(q_id, source_emu_model);
+      cb_conf->UID(), run_marker, crtgrenoble_rate_khz);
+    register_node(cb_conf->UID(), source_emu_model);
     return source_emu_model;
   }
 

--- a/plugins/SNBFileReaderModule.hpp
+++ b/plugins/SNBFileReaderModule.hpp
@@ -15,6 +15,7 @@
 #include "appfwk/ConfigurationManager.hpp"
 #include "appfwk/DAQModule.hpp"
 
+#include "appmodel/DataMoveCallbackConf.hpp"
 #include "snbmodules/readout/FileReaderBase.hpp"
 
 #include <string>
@@ -42,7 +43,7 @@ public:
 
   void init(std::shared_ptr<appfwk::ConfigurationManager> cfg) override;
 
-  std::shared_ptr<snbmodules::FileSourceConcept> create_source_emulator(std::string qi,
+  std::shared_ptr<snbmodules::FileSourceConcept> create_source_emulator(const appmodel::DataMoveCallbackConf* cb_conf,
                                                                         std::atomic<bool>& run_marker) override;
 };
 


### PR DESCRIPTION
# Description

The recent DataMoveCallbackRegistry changes (#25) did not include the necessary changes to FileReaderSource and other SNBModules readout code to actually use the DMCR. This caused `simple_transform_test.py` to start failing in the nightly CI runs.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

_Comments here on the testing_
Tested that simple_transform_test.py passes multiple times in succession, and passes with larger input binary files.
