### PR TITLE
 Delayed postprocessing attribute name changes

### DIFF
--- a/include/snbmodules/readout/SNBDataHandlingModel.hpp
+++ b/include/snbmodules/readout/SNBDataHandlingModel.hpp
@@ -169,8 +169,8 @@ protected:
   daqdataformats::SourceID m_sourceid;
   daqdataformats::run_number_t m_run_number;
   uint64_t m_processing_delay_ticks;
-  uint64_t m_post_processing_delay_min_wait;
-  uint64_t m_post_processing_delay_max_wait;
+  uint64_t m_post_processing_delay_min_wait_ms;
+  uint64_t m_post_processing_delay_max_wait_ms;
 
   // STATS
   using metric_t = dunedaq::datahandlinglibs::opmon::DataHandlerInfo;
@@ -182,8 +182,8 @@ protected:
     std::remove_const<std::invoke_result<decltype(&metric_t::num_data_input_timeouts), metric_t>::type>::type;
   using num_lb_insert_failures_t =
     std::remove_const<std::invoke_result<decltype(&metric_t::num_lb_insert_failures), metric_t>::type>::type;
-  using num_post_processing_delay_max_waits_t = std::remove_const<
-    std::invoke_result<decltype(&metric_t::num_post_processing_delay_max_waits), metric_t>::type>::type;
+  using num_postprocess_schedule_timeouts_t = std::remove_const<
+    std::invoke_result<decltype(&metric_t::num_postprocess_schedule_timeouts), metric_t>::type>::type;
 
   std::atomic<num_payload_t> m_num_payloads{ 0 };
   std::atomic<sum_payload_t> m_sum_payloads{ 0 };
@@ -191,7 +191,7 @@ protected:
   std::atomic<sum_request_t> m_sum_requests{ 0 };
   std::atomic<rawq_timeout_count_t> m_rawq_timeout_count{ 0 };
   std::atomic<num_lb_insert_failures_t> m_num_lb_insert_failures{ 0 };
-  std::atomic<num_post_processing_delay_max_waits_t> m_num_post_processing_delay_max_waits{ 0 };
+  std::atomic<num_postprocess_schedule_timeouts_t> m_num_postprocess_schedule_timeouts{ 0 };
   std::atomic<int> m_stats_packet_count{ 0 };
 
   // CONSUMER

--- a/include/snbmodules/readout/detail/SNBDataHandlingModel.hxx
+++ b/include/snbmodules/readout/detail/SNBDataHandlingModel.hxx
@@ -52,8 +52,8 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::init(const appmodel::DataHandlerM
   m_sourceid.id = mcfg->get_source_id();
   m_sourceid.subsystem = RDT::subsystem;
   m_processing_delay_ticks = mcfg->get_module_configuration()->get_post_processing_delay_ticks();
-  m_post_processing_delay_min_wait = mcfg->get_module_configuration()->get_post_processing_delay_min_wait();
-  m_post_processing_delay_max_wait = mcfg->get_module_configuration()->get_post_processing_delay_max_wait();
+  m_post_processing_delay_min_wait_ms = mcfg->get_module_configuration()->get_post_processing_delay_min_wait_ms();
+  m_post_processing_delay_max_wait_ms = mcfg->get_module_configuration()->get_post_processing_delay_max_wait_ms();
 
   // Configure implementations:
   m_raw_processor_impl->conf(mcfg);
@@ -102,7 +102,7 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::start(const appfwk::DAQModule::Co
   m_num_lb_insert_failures = 0;
   m_stats_packet_count = 0;
   m_rawq_timeout_count = 0;
-  m_num_post_processing_delay_max_waits = 0;
+  m_num_postprocess_schedule_timeouts = 0;
 
   m_t0 = std::chrono::high_resolution_clock::now();
 
@@ -176,7 +176,7 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::generate_opmon_data()
   ri.set_num_lb_insert_failures(local_num_lb_insert_failures);
   ri.set_sum_requests(m_sum_requests.load());
   ri.set_num_requests(m_num_requests.exchange(0));
-  ri.set_num_post_processing_delay_max_waits(m_num_post_processing_delay_max_waits.exchange(0));
+  ri.set_num_postprocess_schedule_timeouts(m_num_postprocess_schedule_timeouts.exchange(0));
   ri.set_last_daq_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_newest_timestamp(m_raw_processor_impl->get_last_daq_time());
   ri.set_oldest_timestamp(m_request_handler_impl->get_oldest_time());
@@ -270,10 +270,10 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
   while (m_run_marker.load()) {
     try {
       co_await folly::coro::timeout(
-        m_baton.operator co_await(), std::chrono::milliseconds{ m_post_processing_delay_max_wait }, m_timekeeper.get());
+        m_baton.operator co_await(), std::chrono::milliseconds{ m_post_processing_delay_max_wait_ms }, m_timekeeper.get());
       m_baton.reset();
     } catch (const folly::FutureTimeout&) {
-      ++m_num_post_processing_delay_max_waits;
+      ++m_num_postprocess_schedule_timeouts;
     }
 
     if (m_latency_buffer_impl->occupancy() == 0) {
@@ -283,7 +283,7 @@ SNBDataHandlingModel<RDT, RHT, LBT, RPT, IDT>::postprocess_schedule()
     now = std::chrono::system_clock::now();
     milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_post_proc_time);
 
-    if (static_cast<uint64_t>(milliseconds.count()) <= m_post_processing_delay_min_wait) {
+    if (static_cast<uint64_t>(milliseconds.count()) <= m_post_processing_delay_min_wait_ms) {
       continue;
     }
 


### PR DESCRIPTION
Added _ms suffix to wall-clock attributes of delayed postprocessing.

PS: These changes are meant for the next release. 

[datahandlinglibs](https://github.com/DUNE-DAQ/datahandlinglibs/pull/132) dte/delayed_pp_monitoring
[appmodel](https://github.com/DUNE-DAQ/appmodel/pull/286) dte/delayedpp_attrs
[daqsystemtest](https://github.com/DUNE-DAQ/daqsystemtest/pull/311) dte/delayedpp_attrs
[snbmodules](https://github.com/DUNE-DAQ/snbmodules/pull/29) dte/delayedpp_attrs
[ehn1-daqconfigs](https://gitlab.cern.ch/dune-daq/online/ehn1-daqconfigs/-/merge_requests/279) dte/delayedpp_attrs