### PR TITLE
initial changes to adapt to confgen (integtest config params) improvements

### DIFF
--- a/integtest/simple_transform_test.py
+++ b/integtest/simple_transform_test.py
@@ -59,20 +59,6 @@ ignored_logfile_problems = {
     "ru-det-conn": ["Request timed out for trig/seq_num"],
 }
 
-# The next three variable declarations *must* be present as globals in the test
-# file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and drunc
-
-# The arguments to pass to the config generator, excluding the json
-# output directory (the test framework handles that)
-
-# CCM includes FSM, hosts; moduleconfs includes connections
-object_databases = [
-    "config/daqsystemtest/integrationtest-objects.data.xml",
-    "config/snbmodules/simple-transform-test.data.xml",
-]
-
-
 dal = conffwk.dal.module("generated", "schema/appmodel/fdmodules.schema.xml")
 db = conffwk.Configuration(
     "oksconflibs:config/snbmodules/simple-transform-test.data.xml"
@@ -119,7 +105,11 @@ for trig_n,trig in enumerate(ft_conf.triggers):
     sequence_count = sequence_count + (trig_len // sequence_length) + 1
 
 
-conf_dict = data_classes.drunc_config()
+conf_dict = data_classes.integtest_params_for_generated_dunedaq_config()
+conf_dict.object_databases = [
+    "config/daqsystemtest/integrationtest-objects.data.xml",
+    "config/snbmodules/simple-transform-test.data.xml",
+]
 conf_dict.dro_map_config = None
 conf_dict.op_env = "integtest"
 conf_dict.config_session_name = "snb-transform-simple"


### PR DESCRIPTION
# Description

These changes are intended for `fddaq-v5.7.0`.

They need to be tested and merged in conjunction with DUNE-DAQ/integrationtest#155 and branches in other repositories.  Please see the `integrationtest` PR for suggested testing instructions.

The changes in this repository react to, and take advantage of, changes in the `integrationtest` infrastructure that attempt to make it easier to specify and understand the parameters that drive each test. 

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
